### PR TITLE
Add solr shim for summary collection

### DIFF
--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 importlib
+argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
 apachelog==1.0
 arrow==0.4.2
+futures==2.1.6
 geoip2==0.5.0
 httmock==1.2
 ipaddr==2.1.11
 maxminddb==0.3.1
 mongobox==0.1.3
 nose==1.3.0
-pycountry==1.3
+pycountry==1.8
 pymongo==2.6.3
+pysolr==3.2.0
 python-dateutil==2.2
 requests==2.2.1
 six==1.5.2

--- a/solr/index.py
+++ b/solr/index.py
@@ -1,0 +1,47 @@
+import pysolr
+import pymongo
+from operator import itemgetter
+import argparse
+
+
+def index(**kwargs):
+    solr = pysolr.Solr(kwargs.get('solr'))
+    mongo = pymongo.MongoClient(kwargs.get('mongohost'))
+    requests = mongo[kwargs.get('database')][kwargs.get('collection')]
+
+    solr_buffer = []
+
+    for request in requests.find():
+        solrdoc = {
+            'handle': request.get('handle'),
+            'title': request.get('title'),
+            'country': request.get('country'),
+            'time': request.get('time'),
+            'dlc_display': map(itemgetter('display'), request.get('dlcs', [])),
+            'dlc_canonical': map(itemgetter('canonical'), request.get('dlcs', [])),
+            'author_id': map(itemgetter('mitid'), request.get('authors', [])),
+            'author_name': map(itemgetter('name'), request.get('authors', [])),
+        }
+        solr_buffer.append(solrdoc)
+
+        if len(solr_buffer) > 9999:
+            solr.add(solr_buffer, commit=False)
+            solr_buffer = []
+
+    if solr_buffer:
+        solr.add(solr_buffer)
+
+    solr.commit()
+
+def main():
+    parser = argparse.ArgumentParser(description="Index Mongo collection in Solr")
+    parser.add_argument('-s' , '--solr', help='Solr instance URL', required=True)
+    parser.add_argument('-m', '--mongohost', help='Mongo host or MongoDB URI')
+    parser.add_argument('-d', '--database', default='oastats')
+    parser.add_argument('-c', '--collection', default='requests')
+    args = parser.parse_args()
+    index(**vars(args))
+
+
+if __name__ == '__main__':
+    main()

--- a/solr/summarize.py
+++ b/solr/summarize.py
@@ -1,0 +1,169 @@
+import futures
+import pymongo
+import pysolr
+import logging
+import sys
+import argparse
+import requests
+
+parser = argparse.ArgumentParser(description="Generate Mongo summary collection from Solr")
+parser.add_argument('--solr', help='Solr instance URL', required=True)
+parser.add_argument('--mongo-requests',
+                    help='Mongo host or MongoDB URI for requests collection')
+parser.add_argument('--database-requests',
+                    help='Name of Mongo database for requests collection',
+                    default='oastats')
+parser.add_argument('--collection-requests',
+                    help='Name of Mongo collection for requests collection',
+                    default='requests')
+parser.add_argument('--mongo-summary',
+                    help='Mongo host or MongoDB URI for summary collection')
+parser.add_argument('--database-summary',
+                    help='Name of Mongo database for summary collection',
+                    default='oastats')
+parser.add_argument('--collection-summary',
+                    help='Name of Mongo collection for summary collection',
+                    default='summary')
+parser.add_argument('--num-threads', help='Number of threads to use', type=int,
+                    default=25)
+args = parser.parse_args()
+
+num_threads = args.num_threads
+
+solr = pysolr.Solr(args.solr)
+adapter = requests.adapters.HTTPAdapter(pool_maxsize=num_threads)
+solr.session.mount('http://', adapter)
+
+mongo_requests = pymongo.MongoClient(args.mongo_requests)
+requests = mongo_requests[args.database_requests][args.collection_requests]
+mongo_summary = pymongo.MongoClient(args.mongo_summary)
+summary = mongo_summary[args.database_summary][args.collection_summary]
+
+logger = logging.getLogger()
+logger.addHandler(logging.StreamHandler(sys.stderr))
+
+default_params = {
+    "facet": 'true',
+    "facet.field": "country",
+    "f.country.facet.limit": 250,
+    "facet.range": "time",
+    "facet.range.start": "2010-08-01T00:00:00Z",
+    "facet.range.end": "NOW",
+    "facet.range.gap": "+1DAY",
+}
+
+authors = dict([(int(d['mitid']), d) for d in requests.distinct("authors")])
+
+def dictify(counts, field):
+    return [{field: f[:10], "downloads": i} for f,i in zip(counts[::2], counts[1::2])]
+
+def query_solr(query, params):
+    results = solr.search(query, **params)
+    return results
+
+def update(f):
+    try:
+        doc = f.result()
+        summary.insert(doc)
+    except Exception, e:
+        logger.error(e)
+
+def get_author(author):
+    query = 'author_id:"{0}"'.format(author['mitid'])
+    params = {
+        "rows": 0,
+        "wt": "json",
+        "group": "true",
+        "group.field": "handle",
+        "group.ngroups": "true",
+    }
+    res = query_solr(query, dict(default_params.items() + params.items()))
+    doc = {
+        "_id": author,
+        "type": "author",
+        "size": res.grouped['handle']['ngroups'],
+        "downloads": res.grouped['handle']['matches'],
+        "countries": dictify(res.facets['facet_fields']['country'], "country"),
+        "dates": dictify(res.facets['facet_ranges']['time']['counts'], "date")
+    }
+    return doc
+
+def get_handle(handle):
+    query = 'handle:"{0}"'.format(handle)
+    params = {
+        "rows": 1,
+        "wt": "json",
+    }
+    res = query_solr(query, dict(default_params.items() + params.items()))
+    req = res.docs[0]
+    doc = {
+        "_id": handle,
+        "type": "handle",
+        "title": req['title'],
+        "downloads": res.hits,
+        "countries": dictify(res.facets['facet_fields']['country'], "country"),
+        "dates": dictify(res.facets['facet_ranges']['time']['counts'], "date"),
+        "parents": [authors.get(a) for a in req.get('author_id', [])]
+    }
+    return doc
+
+def get_dlc(dlc):
+    query = 'dlc_canonical:"{0}"'.format(dlc['canonical'])
+    params = {
+        "rows": 0,
+        "wt": "json",
+        "group": "true",
+        "group.field": "handle",
+        "group.ngroups": "true",
+    }
+    res = query_solr(query, dict(default_params.items() + params.items()))
+    doc = {
+        "_id": dlc,
+        "type": "dlc",
+        "size": res.grouped['handle']['ngroups'],
+        "downloads": res.grouped['handle']['matches'],
+        "countries": dictify(res.facets['facet_fields']['country'], "country"),
+        "dates": dictify(res.facets['facet_ranges']['time']['counts'], "date"),
+    }
+    return doc
+
+def get_summary():
+    query = "*"
+    params = {
+        "rows": 0,
+        "wt": "json",
+        "group": "true",
+        "group.field": "handle",
+        "group.ngroups": "true",
+    }
+    res = query_solr(query, dict(default_params.items() + params.items()))
+    doc = {
+        "_id": "Overall",
+        "type": "overall",
+        "size": res.grouped['handle']['ngroups'],
+        "downloads": res.grouped['handle']['matches'],
+        "countries": dictify(res.facets['facet_fields']['country'], "country"),
+        "dates": dictify(res.facets['facet_ranges']['time']['counts'], "date"),
+    }
+    summary.insert(doc)
+
+def main():
+    get_summary()
+    with futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+        for handle in requests.distinct("handle"):
+            job = executor.submit(get_handle, handle)
+            job.add_done_callback(update)
+
+    with futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+        for author in requests.distinct("authors"):
+            job = executor.submit(get_author, author)
+            job.add_done_callback(update)
+
+    with futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+        for dlc in requests.distinct("dlcs"):
+            job = executor.submit(get_dlc, dlc)
+            job.add_done_callback(update)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Generating the summary collection in Mongo is not really feasible
with 2+ million requests. This adds a temporary shim to generate
the summary collection from a transient solr index.
