### PR TITLE
Use python packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .coverage
 .tox
+*.egg-info

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 MIT Libraries
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -14,11 +14,11 @@ from pipeline.load_json import get_collection, insert
 
 
 @click.group()
-def cli():
+def main():
     pass
 
 
-@cli.command()
+@main.command()
 @click.option('--config', envvar='OASTATS_SETTINGS')
 def pipeline(config):
     with open(config) as fp:
@@ -55,4 +55,4 @@ def pipeline(config):
 
 
 if __name__ == '__main__':
-    cli()
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+OAStats Pipeline
+"""
+
+import io
+from setuptools import find_packages, setup
+
+
+with io.open('LICENSE') as f:
+    license = f.read()
+
+
+setup(
+    name='OAStats Pipeline',
+    version='0.1.0',
+    description='Generate download statistics for the Open Access collection',
+    long_description=__doc__,
+    url='https://github.com/MITLibraries/oastats-backend',
+    license=license,
+    author='Mike Graves',
+    author_email='mgraves@mit.edu',
+    packages=find_packages(exclude=['tests']),
+    install_requires=[
+        'PyYAML',
+        'apache-log-parser',
+        'arrow',
+        'click',
+        'futures',
+        'geoip2',
+        'maxminddb',
+        'pycountry',
+        'pymongo',
+        'pysolr',
+        'python-dateutil',
+        'requests',
+        'six',
+        'ua-parser',
+        'user-agents',
+    ],
+    extras_requires={
+        ':python_version=="2.7"': ['ipaddr'],
+    },
+    entry_points={
+        'console_scripts': [
+            'oastats = pipeline.cli:main',
+        ]
+    },
+    classifiers=[
+        'Internal :: Do Not Upload',
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Environment :: Console',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+    ]
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = clean,py27,py33,py34,coverage
-skipsdist = True
 
 [testenv]
 commands = py.test {posargs:--tb=short}


### PR DESCRIPTION
Closes #24. Project is now installable as a package. This exposes
the pipeline script as `oastats`.