### PR TITLE
Adds support for testing on non-localhost docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
   global:
     - SOLR_PORT=8983
     - MONGO_PORT=27018
+    - SOLR_URI=localhost:8983
+    - MONGO_URI=localhost:27018
   matrix:
     - TOX_ENV=py27-travis
     - TOX_ENV=py33-travis

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,18 +9,18 @@ import yaml
 
 
 @pytest.fixture
-def solr_port():
-    return os.environ['SOLR_PORT']
+def solr_uri():
+    return os.environ['SOLR_URI']
 
 
 @pytest.fixture
-def mongo_port():
-    return int(os.environ['MONGO_PORT'])
+def mongo_uri():
+    return os.environ['MONGO_URI']
 
 
 @pytest.fixture
-def mongo_client(mongo_port):
-    return pymongo.MongoClient('mongodb://localhost:%s' % mongo_port)
+def mongo_client(mongo_uri):
+    return pymongo.MongoClient('mongodb://%s' % mongo_uri)
 
 
 @pytest.fixture
@@ -31,8 +31,8 @@ def load_mongo_records(mongo_client):
 
 
 @pytest.fixture
-def solr_client(solr_port):
-    return pysolr.Solr('http://localhost:%s/solr/oastats' % solr_port)
+def solr_client(solr_uri):
+    return pysolr.Solr('http://%s/solr/oastats' % solr_uri)
 
 
 @pytest.fixture

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -20,24 +20,24 @@ def runner():
     return CliRunner()
 
 
-def test_pipeline_adds_request(runner, mongo_port, cfg, apache_req):
+def test_pipeline_adds_request(runner, mongo_uri, cfg, apache_req):
     with open(cfg) as fp:
         config = yaml.load(fp)
-    config['MONGO_CONNECTION'] = 'mongodb://localhost:%d' % mongo_port
+    config['MONGO_CONNECTION'] = 'mongodb://%s' % mongo_uri
     with patch('pipeline.cli._load_config') as conf:
         with patch('pipeline.pipeline.fetch_metadata') as dspace:
             dspace.return_value = {'foo': 'bar'}
             conf.return_value = config
             runner.invoke(main, ['pipeline', '--config', cfg], apache_req)
-    c = pymongo.MongoClient('mongodb://localhost:%s' % mongo_port)
+    c = pymongo.MongoClient('mongodb://%s' % mongo_uri)
     req = c.oastats.requests.find_one()
     assert req['foo'] == 'bar'
 
 
-def test_pipeline_processes_request(runner, mongo_port, cfg, apache_req):
+def test_pipeline_processes_request(runner, mongo_uri, cfg, apache_req):
     with open(cfg) as fp:
         config = yaml.load(fp)
-    config['MONGO_CONNECTION'] = 'mongodb://localhost:%d' % mongo_port
+    config['MONGO_CONNECTION'] = 'mongodb://%s' % mongo_uri
     with patch('pipeline.cli._load_config') as conf:
         with patch('pipeline.pipeline.fetch_metadata') as dspace:
             conf.return_value = config
@@ -53,12 +53,12 @@ def test_pipeline_processes_request(runner, mongo_port, cfg, apache_req):
 
 
 @pytest.mark.usefixtures('load_mongo_records')
-def test_index_adds_mongo_records_to_solr(runner, solr_port, mongo_port):
+def test_index_adds_mongo_records_to_solr(runner, solr_uri, mongo_uri):
     runner.invoke(main, ['index',
-                         'http://localhost:%s/solr/oastats' % solr_port,
-                         '--mongo', 'mongodb://localhost:%s' % mongo_port])
+                         'http://%s/solr/oastats' % solr_uri,
+                         '--mongo', 'mongodb://%s' % mongo_uri])
 
-    solr = pysolr.Solr('http://localhost:%s/solr/oastats' % solr_port)
+    solr = pysolr.Solr('http://%s/solr/oastats' % solr_uri)
     r = solr.search('*:*')
     assert len(r) == 2
     doc = next(iter(r))
@@ -72,12 +72,12 @@ def test_index_adds_mongo_records_to_solr(runner, solr_port, mongo_port):
 
 
 @pytest.mark.usefixtures('load_mongo_records', 'load_solr_records')
-def test_summary_summarizes_requests(runner, solr_port, mongo_port):
+def test_summary_summarizes_requests(runner, solr_uri, mongo_uri):
     runner.invoke(main, ['summary',
-                         'http://localhost:%s/solr/oastats' % solr_port,
+                         'http://%s/solr/oastats' % solr_uri,
                          '2015-02-01T00:00:00Z', '--mongo',
-                         'mongodb://localhost:%s' % mongo_port])
-    c = pymongo.MongoClient('mongodb://localhost:%s' % mongo_port)
+                         'mongodb://%s' % mongo_uri])
+    c = pymongo.MongoClient('mongodb://%s' % mongo_uri)
     a = c.oastats.summary.find_one({'_id': {'name': 'Baz, Foo',
                                             'mitid': '5678'}})
     assert a['type'] == 'author'

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     coveralls: coveralls
     py33,py34: -r{toxinidir}/requirements.txt
     py27: -r{toxinidir}/requirements-py2.txt
+passenv = DOCKER_HOST DOCKER_CERT_PATH DOCKER_MACHINE_NAME DOCKER_TLS_VERIFY DOCKER_IP
 
 [testenv:coverage]
 basepython = python3.4
@@ -27,7 +28,7 @@ commands =
 
 [testenv:coveralls]
 basepython = python3.4
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH MONGO_PORT SOLR_PORT
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH MONGO_URI SOLR_URI
 commands =
     {toxinidir}/tests/run_tests.sh --cov
     coveralls
@@ -36,7 +37,7 @@ commands =
 basepython = python3.4
 
 [testenv:travis]
-passenv = MONGO_PORT SOLR_PORT
+passenv = MONGO_URI SOLR_URI
 commands = {toxinidir}/tests/run_tests.sh
 
 [testenv:py27-travis]


### PR DESCRIPTION
Supports docker not running on localhost. Or at least the subset of
that possibility in which `docker-machine` is being used.

closes #44