### PR TITLE
Specify all fields for overall query

### DIFF
--- a/pipeline/summary.py
+++ b/pipeline/summary.py
@@ -159,10 +159,10 @@ def get_overall():
         "group.field": "handle",
         "group.ngroups": "true",
     }
-    return '*', params
+    return '*:*', params
 
 
-def create_overall(future): #result):
+def create_overall(future):
     result = future.result()
     return {
         '$set': {

--- a/tests/unit/test_summary.py
+++ b/tests/unit/test_summary.py
@@ -189,7 +189,7 @@ def test_create_handle_creates_mongo_insert(handle_result):
 
 
 def test_get_overall_returns_solr_query():
-    assert get_overall() == ('*', {'rows': 0, 'group': 'true',
+    assert get_overall() == ('*:*', {'rows': 0, 'group': 'true',
                                    'group.field': 'handle',
                                    'group.ngroups': 'true'})
 


### PR DESCRIPTION
This will cover the case when a default query field has not been
specified in the Solr config.