### PR TITLE
Use mongodb uri throughout

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,4 @@
-MONGO_CONNECTION:
-  - localhost
-  - 27017
+MONGO_CONNECTION: 'mongodb://localhost:27017'
 MONGO_DB: oastats
 MONGO_COLLECTION: requests
 GEOIP_DB: tests/fixtures/GeoLite2-Country.mmdb

--- a/pipeline/request_writer.py
+++ b/pipeline/request_writer.py
@@ -23,7 +23,7 @@ def buffered(maxsize=1):
 
 class BufferedMongoWriter(object):
     def __init__(self, db, collection, conn):
-        client = MongoClient(*conn)
+        client = MongoClient(conn)
         self.collection = client[db][collection]
 
     def __enter__(self):

--- a/tests/fixtures/test-config.yml
+++ b/tests/fixtures/test-config.yml
@@ -1,6 +1,4 @@
-MONGO_CONNECTION:
-  - localhost
-  - 27017
+MONGO_CONNECTION: mongodb://localhost:27017
 MONGO_DB: oastats
 MONGO_COLLECTION: requests
 GEOIP_DB: tests/fixtures/GeoLite2-Country.mmdb

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -23,7 +23,7 @@ def runner():
 def test_pipeline_adds_request(runner, mongo_port, cfg, apache_req):
     with open(cfg) as fp:
         config = yaml.load(fp)
-    config['MONGO_CONNECTION'] = ['localhost', mongo_port]
+    config['MONGO_CONNECTION'] = 'mongodb://localhost:%d' % mongo_port
     with patch('pipeline.cli._load_config') as conf:
         with patch('pipeline.pipeline.fetch_metadata') as dspace:
             dspace.return_value = {'foo': 'bar'}
@@ -37,7 +37,7 @@ def test_pipeline_adds_request(runner, mongo_port, cfg, apache_req):
 def test_pipeline_processes_request(runner, mongo_port, cfg, apache_req):
     with open(cfg) as fp:
         config = yaml.load(fp)
-    config['MONGO_CONNECTION'] = ['localhost', mongo_port]
+    config['MONGO_CONNECTION'] = 'mongodb://localhost:%d' % mongo_port
     with patch('pipeline.cli._load_config') as conf:
         with patch('pipeline.pipeline.fetch_metadata') as dspace:
             conf.return_value = config

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -20,7 +20,7 @@ def test_run_adds_requests_to_mongo(mongo):
     with patch('pipeline.pipeline.process') as mock:
         mock.side_effect = [{'foo': 'bar'}, {'foo': 'baz'}]
         run(['foo', 'bar'], MONGO_DB='oastats', MONGO_COLLECTION='requests',
-            MONGO_CONNECTION=['localhost', mongo.port])
+            MONGO_CONNECTION='mongodb://localhost:%d' % mongo.port)
     assert mongo.client().oastats.requests.count({'foo': 'baz'}) == 1
     assert mongo.client().oastats.requests.count({'foo': 'bar'}) == 1
 

--- a/tests/unit/test_request_writer.py
+++ b/tests/unit/test_request_writer.py
@@ -38,14 +38,16 @@ def test_buffered_does_not_write_empty_list(Foo):
 
 
 def test_mongo_writer_adds_requests(mongo):
-    m = BufferedMongoWriter('foo', 'bar', ['localhost', mongo.port])
+    m = BufferedMongoWriter('foo', 'bar',
+                            'mongodb://localhost:%d' % mongo.port)
     m.write({'foo': 'bar'})
     m.write()
     assert m.collection.count({'foo': 'bar'}) == 1
 
 
 def test_mongo_writer_flushes_on_exit(mongo):
-    with BufferedMongoWriter('foo', 'bar', ['localhost', mongo.port]) as m:
+    with BufferedMongoWriter('foo', 'bar',
+                             'mongodb://localhost:%d' % mongo.port) as m:
         m.write({'foo': 'gaz'})
     assert m.collection.count({'foo': 'gaz'}) == 1
 


### PR DESCRIPTION
Closes #49. This requires all mongo connections to be specified
using the mongodb:// uri instead of passing host/port as a list.