### PR TITLE
Add support for UTF-8 characters in identities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 services:
     - docker
 notifications:
@@ -23,7 +24,7 @@ before_install:
     - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
     - echo "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
     - sudo apt-get update
-    - sudo apt-get install lxc-docker mongodb-org
+    - sudo apt-get install -y mongodb-org
     - docker pull mitlibraries/oastats-solr
     - docker run -d -p 8983:8983 mitlibraries/oastats-solr
     - docker pull mongo

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -5,6 +5,7 @@ import logging
 import logging.config
 import re
 import json
+import sys
 
 import yaml
 import click
@@ -79,9 +80,11 @@ def summary(solr, end_date, mongo, mongo_req_db, mongo_req_collection,
 @main.command()
 @click.argument('tsv', type=click.File(encoding='utf-8'))
 def generate_ids(tsv):
+    if sys.version_info.major < 3:
+        raise click.UsageError('This subcommand requires python 3')
     ids = load_identities(tsv)
     for identity in generate_identities(ids):
-        click.echo(json.dumps(identity))
+        click.echo(json.dumps(identity, ensure_ascii=False))
 
 
 def _load_config(cfg_file):

--- a/tests/fixtures/identities.csv
+++ b/tests/fixtures/identities.csv
@@ -2,3 +2,4 @@ Author	ID	Date Issued	URI	Match count	MIT ID	Column
 Bar, Foo	1234	2015-01	http://example.com/1	1 match	1000	
 Baz, Foo	5678	2015-01	http://example.com/2	2 matches	2000	abc
 Gaz, Foo	666	2015-01	http://example.com/1	1 match	3000	
+βar, Foo	9999	2015-01	http://example.com/3	1 match	0001	

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import json
+import sys
 
 import pytest
 from mock import patch
@@ -90,6 +91,7 @@ def test_solr_date_type_passes_valid_date_type_through(runner):
     assert r.output == '2015-01-01T00:00:00Z\n'
 
 
+@pytest.mark.skipif(sys.version_info.major < 3, reason="requires python3")
 def test_generate_ids_outputs_list_of_json_objects(runner, identities):
     r = runner.invoke(main, ['generate_ids', identities])
     out = r.output.split('\n')
@@ -101,4 +103,14 @@ def test_generate_ids_outputs_list_of_json_objects(runner, identities):
     assert json.loads(out[1]) == {
         'handle': 'http://example.com/2',
         'ids': [{'name': 'Baz, Foo', 'mitid': '2000'}]
+    }
+
+
+@pytest.mark.skipif(sys.version_info.major < 3, reason="requires python3")
+def test_generate_ids_handles_non_ascii(runner, identities):
+    r = runner.invoke(main, ['generate_ids', identities])
+    out = r.output.split('\n')
+    assert json.loads(out[2]) == {
+        'handle': 'http://example.com/3',
+        'ids': [{'name': 'βar, Foo', 'mitid': '0001'}]
     }

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands =
     {toxinidir}/tests/run_integration.sh --cov
 
 [testenv:coveralls]
-basepython = python3.4
+basepython = python3.3
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH MONGO_URI SOLR_URI
 commands =
     {toxinidir}/tests/run_tests.sh --cov


### PR DESCRIPTION
This fix should properly handle non-ascii characters in the
identities file. Supporting this in python < 3 is a pain due to the
way the csv module works, so the generate_ids subcommand will only
run under python 3.